### PR TITLE
Fixes #13 Sphinx build error for python 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Sphinx build error for python 3.9 [#13](https://github.com/IN-CORE/pyincore-incubator/issues/13)
+

--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - sphinx<8.0.0
   - scip>=8.0.0
   - pyincore


### PR DESCRIPTION
Sphinx 8 requires python 3.10 or higher, but we require 3.9 or higher. I pinned sphinx to <8.